### PR TITLE
correct go.mod module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hashicorp/vault-plugin-secrets-kv
+module github.com/openbao/openbao-plugin-secrets-kv
 
 go 1.16
 


### PR DESCRIPTION
This corrects `go.mod` to properly report `github.com/openbao/openbao-secrets-kv`.